### PR TITLE
script edits for nu pmc project, adding pfpr analyzer for U2 age group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+analyzers/__pycache__/
+compare_to_data/__pycache__/

--- a/analyzers/analyze.py
+++ b/analyzers/analyze.py
@@ -54,30 +54,64 @@ def analyze_experiment(platform, expid, wdir):
                                                 end_day = sim_years*365,
                                                 channels=["Daily EIR"]))
     if coord_df.at['prevalence_comparison','value']:
-        prevalence_df = pd.read_csv(os.path.join(manifest.base_reference_filepath,
+        prevalence_df_U5 = pd.read_csv(os.path.join(manifest.base_reference_filepath,
                                                     coord_df.at['prevalence_comparison_reference','value']))
+
+        prevalence_df_U2 = pd.read_csv(os.path.join(manifest.base_reference_filepath,
+                                                     coord_df.at['prevalence_comparison_reference_U2','value']))
+
         if(coord_df.at['prevalence_comparison_diagnostic','value']=="PCR"):
-            prevalence_start = int(prevalence_df['year'].min()) - sim_start_year
-            prevalence_end = int(prevalence_df['year'].max()) - sim_start_year
+            prevalence_start_u5 = int(prevalence_df_U5['year'].min()) - sim_start_year
+            prevalence_end_u5 = int(prevalence_df_U5['year'].max()) - sim_start_year
             analyzers.append(PCRAnalyzer(sweep_variables=sweep_variables,
                                                 working_dir=wdir,
-                                                start_day=prevalence_start*365,
-                                                end_day = 365+prevalence_end*365,
+                                                start_day=prevalence_start_u5*365,
+                                                end_day = 365+prevalence_end_u5*365,
                                                 channels=["PCR Parasite Prevalence"]))
+        
         if coord_df.at['prevalence_comparison_diagnostic','value']=="Microscopy":
-            prevalence_start = int(prevalence_df['year'].min())
-            prevalence_end = int(prevalence_df['year'].max())
+            prevalence_start_u5 = int(prevalence_df_U5['year'].min())
+            prevalence_end_u5 = int(prevalence_df_U5['year'].max())
             if coord_df.at['prevalence_comparison_frequency','value']=="monthly":
-                print(f"Prevalence: {prevalence_start} to {prevalence_end}")
+                print(f"Prevalence: {prevalence_start_u5} to {prevalence_end_u5}")
                 analyzers.append(MonthlyPfPRAnalyzer(sweep_variables=sweep_variables,
                                                      working_dir=wdir,
-                                                     start_year=prevalence_start,
-                                                     end_year=prevalence_end))
+                                                     start_year=prevalence_start_u5,
+                                                     end_year= prevalence_end_u5,
+                                                     grp = 'U5'))
+                                                     
+            prevalence_start_u2 = int(prevalence_df_U2['year'].min())
+            prevalence_end_u2 = int(prevalence_df_U2['year'].max()+1)
+            if coord_df.at['prevalence_comparison_frequency','value']=="monthly":
+                print(f"Prevalence: {prevalence_start_u2} to {prevalence_end_u2}")
+                analyzers.append(MonthlyPfPRAnalyzer(sweep_variables=sweep_variables,
+                                                     working_dir=wdir,
+                                                     start_year=prevalence_start_u2,
+                                                     end_year=prevalence_end_u2,
+                                                     grp = 'U2'))
+
+        if(coord_df.at['prevalence_comparison_diagnostic','value']=="PCR"):
+            prevalence_start_u2 = int(prevalence_df_U2['year'].min()) - sim_start_year
+            prevalence_end_u2 = int(prevalence_df_U2['year'].max()) - sim_start_year
+            analyzers.append(PCRAnalyzer(sweep_variables=sweep_variables,
+                                                working_dir=wdir,
+                                                start_day=prevalence_start_u2*365,
+                                                end_day = 365+prevalence_end_u2*365,
+                                                channels=["PCR Parasite Prevalence"]))
+        
+        if coord_df.at['prevalence_comparison_diagnostic','value']=="Microscopy":
+
             if coord_df.at['prevalence_comparison_frequency','value']=="annual":
                 analyzers.append(AnnualPfPRAnalyzer(sweep_variables=sweep_variables,
                                                     working_dir=wdir,
-                                                    start_year=prevalence_start,
-                                                    end_year=prevalence_end))
+                                                    start_year=prevalence_start_u5,
+                                                    end_year=prevalence_end_u5))
+
+            if coord_df.at['prevalence_comparison_frequency','value']=="annual":
+                analyzers.append(AnnualPfPRAnalyzer(sweep_variables=sweep_variables,
+                                                    working_dir=wdir,
+                                                    start_year=prevalence_start_u2,
+                                                    end_year=prevalence_end_u2))
     # Don't change these - used for fitting #
     if coord_df.at['incidence_comparison','value']:
         incidence_df = pd.read_csv(os.path.join(manifest.base_reference_filepath,

--- a/analyzers/analyzer_collection.py
+++ b/analyzers/analyzer_collection.py
@@ -91,12 +91,13 @@ class MonthlyPfPRAnalyzer(IAnalyzer):
         working_dir="./",
         start_year=2000,
         end_year=2001,
+        grp = 'U5',
         filter_exists=False,
     ):
         super(MonthlyPfPRAnalyzer, self).__init__(
             working_dir=working_dir,
             filenames=[
-                f"output/MalariaSummaryReport_Monthly_prevalence_{x}.json"
+                f"output/MalariaSummaryReport_Monthly_prevalence_{grp}_{x}.json"
                 for x in range(start_year, end_year)
             ],
         )
@@ -104,6 +105,7 @@ class MonthlyPfPRAnalyzer(IAnalyzer):
         self.start_year = start_year
         self.end_year = end_year
         self.filter_exists = filter_exists
+        self.grp = grp
 
     def filter(self, simulation: Simulation):
         if self.filter_exists:
@@ -151,7 +153,7 @@ class MonthlyPfPRAnalyzer(IAnalyzer):
 
         adf = pd.concat(selected).reset_index(drop=True)
         adf.to_csv(
-            (os.path.join(self.working_dir, "PfPR_monthly.csv")),
+            (os.path.join(self.working_dir, f"PfPR_monthly_{self.grp}.csv")),
             index=False,
         )
 

--- a/analyzers/analyzer_pfprcase.py
+++ b/analyzers/analyzer_pfprcase.py
@@ -5,13 +5,16 @@ import os
 from idmtools.analysis.analyze_manager import AnalyzeManager
 from idmtools.core import ItemType
 from idmtools.core.platform_factory import Platform
+import pandas as pd
 
 # from within analyzers/
 from .analyzer_collection import (EventReporterAnalyzer, 
                                 MonthlyPfPRAnalyzer,
                                 InsetChartAnalyzer)
 # from source 'simulations' directory
-sys.path.append("../../simulations")
+sys.path.append("../../")
+from environment_calibration.helpers import load_coordinator_df
+sys.path.append("/simulations")
 import manifest
 
 def parse_args():
@@ -33,12 +36,56 @@ if __name__ == "__main__":
                        'Constant_Multiplier', 'CM_Coverage']
     channels = ['Adult Vectors', 'Daily EIR', 'Daily Bites per Human', 'Rainfall']
 
+    coord_df = load_coordinator_df(characteristic=False, set_index=True)
+    simulation_years = int(coord_df.at['simulation_years','value'])
+    sim_start_year = int(coord_df.at['simulation_start_year','value'])
+
+    prevalence_df_U5 = pd.read_csv(os.path.join(manifest.base_reference_filepath,
+                                                     coord_df.at['prevalence_comparison_reference','value']))
+
+    prevalence_df_U2 = pd.read_csv(os.path.join(manifest.base_reference_filepath,
+                                                     coord_df.at['prevalence_comparison_reference_U2','value']))
+
+    prevalence_agebins = sorted([float(a) for a in prevalence_df_U5['age'].unique()])
+    prevalence_agebins = sorted([float(a) for a in prevalence_df_U2['age'].unique()])
+
+    first_year_U5 = int(prevalence_df_U5['year'].min()) - sim_start_year
+    last_year_U5 = int(prevalence_df_U5['year'].max()) - sim_start_year
+
+    first_year_U2 = int(prevalence_df_U2['year'].min()) - sim_start_year
+    last_year_U2 = int(prevalence_df_U2['year'].max()) - sim_start_year
+
+    # Logical bounds on years to request
+    first_year = max(first_year, 0)
+    last_year = min(last_year, simulation_years)
+
+    first_year_U5 = max(first_year_U5, 0)
+    last_year_U5 = min(last_year_U5, simulation_years)
+
+    first_year_U2 = max(first_year_U2, 0)
+    last_year_U2 = min(last_year_U2, simulation_years)
+
+
+
     with Platform('SLURM_LOCAL', job_directory=manifest.job_directory) as platform:
         analyzers = []
         analyzers.append(MonthlyPfPRAnalyzer(sweep_variables=sweep_variables,
                                             start_year=2015,
                                             end_year=2019,
                                             working_dir=wdir))
+                                            
+        analyzers.append(MonthlyPfPRAnalyzer(sweep_variables=sweep_variables,
+                                            start_year=2015,
+                                            end_year=2019,
+                                            grp="U5",  # Explicitly setting U5
+                                            working_dir=wdir))
+
+        analyzers.append(MonthlyPfPRAnalyzer(sweep_variables=sweep_variables,
+                                            start_year=2015,
+                                            end_year=2019,
+                                            grp="U2",  # Explicitly setting U2
+                                            working_dir=wdir))
+                                            
         analyzers.append(EventReporterAnalyzer(sweep_variables=sweep_variables,
                                                working_dir=wdir))
         analyzers.append(InsetChartAnalyzer(channels=channels,

--- a/compare_to_data/calculate_all_scores.py
+++ b/compare_to_data/calculate_all_scores.py
@@ -15,13 +15,20 @@ warnings.simplefilter(action='ignore', category=FutureWarning)
 warnings.simplefilter(action='ignore', category=SettingWithCopyWarning)
 pd.options.mode.chained_assignment = None  # default='warn'
 # from within environment_calibration_common submodule
-sys.path.append("../")
-from load_inputs import load_sites
-from helpers import load_coordinator_df
+# sys.path.append("../")
+# from load_inputs import load_sites
+# from helpers import load_coordinator_df
 # from source 'simulations' directory
 sys.path.append("../../simulations")
+
 import manifest
 
+def load_coordinator_df(characteristic=False, set_index=True):
+    csv_file = manifest.sweep_sim_coordinator_path if characteristic else manifest.simulation_coordinator_path
+    coord_df = pd.read_csv(csv_file)
+    if set_index:
+        coord_df = coord_df.set_index('option')
+    return coord_df
 
 coord_df = load_coordinator_df(characteristic=False, set_index=True)
 
@@ -39,6 +46,13 @@ def load_prevalence_data(site):
     ### Load reference PCR prevalence data
     refprev = pd.read_csv(os.path.join(manifest.base_reference_filepath,
                                       coord_df.at['prevalence_comparison_reference','value']))
+    refprev = refprev[refprev['site']==site]
+    return(refprev)
+
+def load_prevalence_data_U2(site):
+    ### Load reference PCR prevalence data
+    refprev = pd.read_csv(os.path.join(manifest.base_reference_filepath,
+                                      coord_df.at['prevalence_comparison_reference_U2','value']))
     refprev = refprev[refprev['site']==site]
     return(refprev)
 
@@ -82,11 +96,16 @@ def compare_PfPR_prevalence(site,agebin):
     #### SCORE - Monthly PCR Parasite Prevalence ####
     #################################################
     # load reference data
-    refpfpr = load_prevalence_data(site)
+    if agebin <= 2:
+        refpfpr = load_prevalence_data_U2(site)
+        fname = "PfPR_monthly_U2.csv"
+    else:
+        refpfpr = load_prevalence_data(site)
+        fname = "PfPR_monthly_U5.csv"
     refpfpr = refpfpr[refpfpr['age'] == agebin]
     # convert reference_pcr 'year' to start at 0, like simulations
     refpfpr['year'] = [(y) for y in refpfpr['year']]
-    sim_pfpr = pd.read_csv(os.path.join(manifest.simulation_output_filepath,site,"PfPR_monthly.csv"))
+    sim_pfpr = pd.read_csv(os.path.join(manifest.simulation_output_filepath,site,fname))
     # filter to age of interest
     sim_pfpr = sim_pfpr[sim_pfpr['agebin']==agebin]
     # get mean PfPR by month, year, and Sample_ID across runs
@@ -203,7 +222,7 @@ def compare_annual_incidence(site,agebin):
     score2['intensity_score'] = score2.apply(lambda row: exp(abs(row['Inc']-target)/target), axis=1)
     return score2
 
-def compute_all_scores(site,incidence_agebin=100,prevalence_agebin=100):
+def compute_all_scores(site,incidence_agebin=100,prevalence_agebin=5, prevalence_agebin_U2=2):
     # merge unweighted scores into one dataframe, and return
     
     scores = check_EIR_threshold(site)
@@ -211,23 +230,24 @@ def compute_all_scores(site,incidence_agebin=100,prevalence_agebin=100):
     if(coord_df.at['incidence_comparison','value']):
         score1 = compare_incidence_shape(site,agebin=incidence_agebin)
         scores = scores.merge(score1[['Sample_ID','shape_score']], how='outer', on='Sample_ID')
-        score2 = compare_annual_incidence(site,agebin=incidence_agebin)
-        scores = scores.merge(score2[['Sample_ID','intensity_score']], how='outer', on='Sample_ID')
+        # score2 = compare_annual_incidence(site,agebin=incidence_agebin)
+        # scores = scores.merge(score2[['Sample_ID','intensity_score']], how='outer', on='Sample_ID')
     if(coord_df.at['prevalence_comparison','value']):
         if(coord_df.at['prevalence_comparison_diagnostic','value']=="PCR"):
             score3 = compare_all_age_PCR_prevalence(site)
             scores = scores.merge(score3[['Sample_ID','prevalence_score']], how='outer', on='Sample_ID')
         if(coord_df.at['prevalence_comparison_diagnostic','value']=="Microscopy"):
             score3 = compare_PfPR_prevalence(site,agebin=prevalence_agebin)
+            score4 = compare_PfPR_prevalence(site,agebin=prevalence_agebin_U2)
             scores = scores.merge(score3[['Sample_ID','prevalence_score']], how='outer', on='Sample_ID')
+            scores = scores.merge(score4[['Sample_ID','prevalence_U2_score']], how='outer', on='Sample_ID')
     return scores
   
   
 
 if __name__ == '__main__':
-  site="Nanoro"
+  site="Aiyedade"
   print(compare_incidence_shape(site,agebin=100))
-  print(compare_annual_incidence(site,agebin=100))
+#   print(compare_annual_incidence(site,agebin=100))
   print(compare_all_age_PCR_prevalence(site))
   print(check_EIR_threshold(site))
-

--- a/compare_to_data/run_full_comparison.py
+++ b/compare_to_data/run_full_comparison.py
@@ -23,8 +23,10 @@ from calculate_all_scores import  compute_all_scores, load_case_data, load_preva
 sys.path.append('../')
 from helpers import load_coordinator_df
 # from source 'simulations' directory
+
 sys.path.append("../../simulations")
 import manifest as manifest
+
 
 
 def compute_scores_across_site(site):
@@ -32,7 +34,8 @@ def compute_scores_across_site(site):
     coord_df = load_coordinator_df()
     incidence_agebin=float(coord_df.at['incidence_comparison_agebin','value'])
     prevalence_agebin=float(coord_df.at['prevalence_comparison_agebin','value'])
-    scores = compute_all_scores(site,incidence_agebin=incidence_agebin,prevalence_agebin=prevalence_agebin)
+    prevalence_agebin_U2=float(coord_df.at['prevalence_comparison_agebin_U2','value'])
+    scores = compute_all_scores(site,incidence_agebin=incidence_agebin,prevalence_agebin=prevalence_agebin, prevalence_agebin_U2 = prevalence_agebin_U2)
     # Load weighting rules
     weights = pd.read_csv(os.path.join(manifest.input_files_path,"weights.csv"),index_col=0)
     
@@ -44,13 +47,17 @@ def compute_scores_across_site(site):
     if(coord_df.at['incidence_comparison','value']):
         scores['shape_score'] = [float(weights.at['shape_score','weight'])*val for val in scores['shape_score']]
         scores['shape_score'] = scores['shape_score'].fillna(10)
-        scores['intensity_score'] = [float(weights.at['intensity_score','weight'])*val for val in scores['intensity_score']]
-        scores['intensity_score'] = scores['intensity_score'].fillna(10)
+        # scores['intensity_score'] = [float(weights.at['intensity_score','weight'])*val for val in scores['intensity_score']]
+        # scores['intensity_score'] = scores['intensity_score'].fillna(10)
     
     ### Add prevalence score ###
     if(coord_df.at['prevalence_comparison','value']):
         scores['prevalence_score'] = [float(weights.at['prevalence_score','weight'])*val for val in scores['prevalence_score']]
         scores['prevalence_score'] = scores['prevalence_score'].fillna(10)
+
+    ### Add prevalence score U2 ###
+        scores['prevalence_U2_score'] = [float(weights.at['prevalence_U2_score','weight'])*val for val in scores['prevalence_U2_score']]
+        scores['prevalence_U2_score'] = scores['prevalence_U2_score'].fillna(10)
 
     scores = scores.rename(columns={"Sample_ID":"param_set"})
     
@@ -147,14 +154,20 @@ def plot_pfpr_microscopy(site="",plt_dir=os.path.join(manifest.simulation_output
         best = pd.read_csv(os.path.join(wdir,"emod.best.csv"))
         best = best['param_set'][0]
 
-    sim_pfpr = sim_pfpr[sim_pfpr['Sample_ID']==best]
+    sim_pfpr_best = sim_pfpr[sim_pfpr['Sample_ID']==best]
     
     sim_pfpr['date'] = sim_pfpr['month'].map(str)+ '-' +sim_pfpr['Year'].map(str)
     sim_pfpr['date'] = pd.to_datetime(sim_pfpr['date'], format='%m-%Y').dt.strftime('%m-%Y')
     sim_pfpr=sim_pfpr.sort_values(['Year','month'])
+    
+    sim_pfpr_best = sim_pfpr[sim_pfpr['Sample_ID']==best]
+    
     # Plot normalized incidence curve vs. reference data
     plt.figure(figsize=(6, 6), dpi=300, tight_layout=True)
-    plt.plot(sim_pfpr['date'],sim_pfpr['PfPR'], label="Simulation")
+    #plt.plot(sim_pfpr['date'], sim_pfpr['PfPR'], label="Simulation (All Runs)", alpha=0.3)
+    plt.plot(sim_pfpr_best['date'], sim_pfpr_best['PfPR'], label="Best Parameter Set", alpha=1.0)
+    
+        
     plt.scatter(refpfpr['date'], refpfpr['prevalence'], label="Reference", color='k')
     plt.xticks(refpfpr['date'], rotation=45)
     plt.legend()
@@ -259,13 +272,15 @@ def plot_allAge_prevalence(site="",plt_dir=os.path.join(manifest.simulation_outp
 
 if __name__ == "__main__":
 
-    workdir="/projects/b1139/environment_calibration/simulations/output/test_pfpr/"
+    # workdir="/projects/b1139/environment_calibration/simulations/output/Aiyedade_trial_1/"
+    workdir="/home/upf3610/b1139/ipti_pmc/environment_calibration/simulations/output/Aiyedade_trial_24/"
+
     plt_dir=workdir
-    site="Nanoro"
+    site="Aiyedade"
     agebin=100
     coord_df = load_coordinator_df()
     start_year = coord_df.at['simulation_start_year','value']
-    
+
     plot_pfpr_microscopy(site=site,plt_dir=plt_dir,wdir=workdir,agebin=100)
     
     
@@ -278,4 +293,3 @@ if __name__ == "__main__":
     # ACI.to_csv(f"{workdir}/LF_{n}/ACI.csv")
     # plot_incidence(site=site, plt_dir=os.path.join(f"{workdir}/LF_{n}"), wdir=os.path.join(f"{workdir}/LF_{n}"),agebin=100)
     # plot_allAge_prevalence(site=site, plt_dir=os.path.join(f"{workdir}/LF_{n}"), wdir=os.path.join(f"{workdir}/LF_{n}"))
-

--- a/helpers.py
+++ b/helpers.py
@@ -120,7 +120,7 @@ def add_outputs(task, site):
         incidence_df = pd.read_csv(os.path.join(manifest.base_reference_filepath,coord_df.at['incidence_comparison_reference','value']))
         incidence_agebins = sorted([float(a) for a in incidence_df['age'].unique()])
         first_year = int(incidence_df['year'].min()) - sim_start_year
-        last_year = int(incidence_df['year'].max()) - sim_start_year + 1
+        last_year = int(incidence_df['year'].max()) - sim_start_year + 2
         
         # Logical bounds on years to request
         if first_year < 0:
@@ -146,41 +146,96 @@ def add_outputs(task, site):
                                        pretty_format=True,
                                        filename_suffix=f"Yearly_incidence_{first_year+sim_start_year}_to_{last_year+sim_start_year}")
     ### Prevalence-related reports ### 
+    # if(coord_df.at['prevalence_comparison','value']):
+    #     if(coord_df.at['prevalence_comparison_diagnostic','value']!="PCR"):
+    #         prevalence_df = pd.read_csv(os.path.join(manifest.base_reference_filepath,
+    #                                                 coord_df.at['prevalence_comparison_reference','value']))
+    #         prevalence_agebins =  sorted([float(a) for a in prevalence_df['age'].unique()])
+    #         first_year = int(prevalence_df['year'].min()) - sim_start_year
+    #         last_year = int(prevalence_df['year'].max()) - sim_start_year
+            
+    #         # Logical bounds on years to request
+    #         if first_year < 0:
+    #             first_year=0
+    #         if last_year > simulation_years:
+    #             last_year=simulation_years
+    #         print(first_year)
+    #         print(last_year)
+    #         print(simulation_years)    
+    #         if(coord_df.at['prevalence_comparison_frequency','value']=='monthly'):
+    #             for year in range(first_year, last_year):
+    #                 start_day = 0 + 365 * year
+    #                 sim_year = sim_start_year + year
+    #                 add_malaria_summary_report(task,manifest,
+    #                                         start_day=start_day,end_day=365 + year * 365,
+    #                                         reporting_interval=30,age_bins=prevalence_agebins,
+    #                                         max_number_reports=13,pretty_format=True,
+    #                                         filename_suffix=f"Monthly_prevalence_{sim_year}")
+                                            
+    #         if(coord_df.at['prevalence_comparison_frequency','value']=='annual'):
+    #             add_malaria_summary_report(task,manifest,
+    #                                     start_day=first_year*365,end_day=last_year*365,
+    #                                     reporting_interval=365,age_bins=prevalence_agebins,
+    #                                     max_number_reports=last_year-first_year+1,
+    #                                     pretty_format=True,
+    #                                     filename_suffix=f"Yearly_prevalence_{first_year+sim_start_year}_to_{last_year+sim_start_year}")
+        
     if(coord_df.at['prevalence_comparison','value']):
         if(coord_df.at['prevalence_comparison_diagnostic','value']!="PCR"):
-            prevalence_df = pd.read_csv(os.path.join(manifest.base_reference_filepath,
-                                                    coord_df.at['prevalence_comparison_reference','value']))
-            prevalence_agebins =  sorted([float(a) for a in prevalence_df['age'].unique()])
-            first_year = int(prevalence_df['year'].min()) - sim_start_year
-            last_year = int(prevalence_df['year'].max()) - sim_start_year + 1
-            
+            prevalence_df_U5 = pd.read_csv(os.path.join(manifest.base_reference_filepath,
+                                                     coord_df.at['prevalence_comparison_reference','value']))
+
+            prevalence_df_U2 = pd.read_csv(os.path.join(manifest.base_reference_filepath,
+                                                     coord_df.at['prevalence_comparison_reference_U2','value']))
+
+            prevalence_agebins_U5 = sorted([float(a) for a in prevalence_df_U5['age'].unique()])
+            prevalence_agebins_U2 = sorted([float(a) for a in prevalence_df_U2['age'].unique()])
+    
+
+            first_year_U5 = int(prevalence_df_U5['year'].min()) - sim_start_year
+            last_year_U5 = int(prevalence_df_U5['year'].max()) - sim_start_year
+
+            first_year_U2 = int(prevalence_df_U2['year'].min()) - sim_start_year
+            last_year_U2 = int(prevalence_df_U2['year'].max()) - sim_start_year
+
             # Logical bounds on years to request
-            if first_year < 0:
-                first_year=0
-            if last_year > simulation_years:
-                last_year=simulation_years
-                
+            first_year = max(first_year, 0)
+            last_year = min(last_year, simulation_years)
+
+            first_year_U5 = max(first_year_U5, 0)
+            last_year_U5 = min(last_year_U5, simulation_years)
+            
+            first_year_U2 = max(first_year_U2, 0)
+            last_year_U2 = min(last_year_U2, simulation_years)
+
             if(coord_df.at['prevalence_comparison_frequency','value']=='monthly'):
-                for year in range(first_year, last_year):
+                for year in range(first_year_U5, last_year_U5+3):
                     start_day = 0 + 365 * year
                     sim_year = sim_start_year + year
-                    add_malaria_summary_report(task,manifest,
-                                               start_day=start_day,end_day=365 + year * 365,
-                                               reporting_interval=30,age_bins=prevalence_agebins,
-                                               max_number_reports=13,pretty_format=True,
-                                               filename_suffix=f"Monthly_prevalence_{sim_year}")
-                                               
+                    add_malaria_summary_report(task, manifest,
+                                                start_day=start_day, end_day=365 + year * 365,
+                                                reporting_interval=30, age_bins=prevalence_agebins_U5,
+                                                max_number_reports=13, pretty_format=True,
+                                                filename_suffix=f"Monthly_prevalence_U5_{sim_year}")
+
+                for year in range(first_year_U2, last_year_U2+1):
+                    start_day = 0 + 365 * year
+                    sim_year = sim_start_year + year
+                    add_malaria_summary_report(task, manifest,
+                                                start_day=start_day, end_day=365 + year * 365,
+                                                reporting_interval=30, age_bins=prevalence_agebins_U2,
+                                                max_number_reports=13, pretty_format=True,
+                                                filename_suffix=f"Monthly_prevalence_U2_{sim_year}")
+
             if(coord_df.at['prevalence_comparison_frequency','value']=='annual'):
-                add_malaria_summary_report(task,manifest,
-                                           start_day=first_year*365,end_day=last_year*365,
-                                           reporting_interval=365,age_bins=prevalence_agebins,
-                                           max_number_reports=last_year-first_year+1,
-                                           pretty_format=True,
-                                           filename_suffix=f"Yearly_prevalence_{first_year+sim_start_year}_to_{last_year+sim_start_year}")
-        
+                add_malaria_summary_report(task, manifest,
+                                            start_day=first_year*365, end_day=last_year*365,
+                                            reporting_interval=365, age_bins=prevalence_agebins_U5,
+                                            max_number_reports=last_year-first_year+1,
+                                            pretty_format=True,
+                                            filename_suffix=f"Yearly_prevalence_{first_year+sim_start_year}_to_{last_year+sim_start_year}")
     return
   
-
 def build_camp(site, coord_df=None):
     """
     Build a campaign input file for the DTK using emod_api.
@@ -568,7 +623,8 @@ def get_comps_id_filename(site: str, level: int = 0):
         file_name = folder_name / (site + '_analyzers')
     else:
         file_name = folder_name / (site + '_download')
-    return file_name.relative_to(manifest.CURRENT_DIR).as_posix()
+    return file_name.as_posix()
+    # return file_name.relative_to(manifest.PROJECT_DIR).as_posix()
 
 
 def load_coordinator_df(characteristic=False, set_index=True):


### PR DESCRIPTION
## Allowing framework to run for 2 overlapping age group
- currently the framework allows for flexible non-overlapping age groups, since the MalariaSummaryReport returns agebins. 
- Instead of aggregating agebins, two separate MalariaSummaryReports are requested, one for U5 (for DHS data) and one for U2 (for data from the project)
- therefore, any mentioning of `prevalence_df` is edited to `prevalence_df_U5` and `prevalence_df_U2`
Note: the plotting scripts have not yet been adapted to plot U5 and U2 (single year) on the same figure (as separate panels)

## Other:
- added __pycache__ to gitignore